### PR TITLE
Fix migrate

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
@@ -1,7 +1,7 @@
 from flask import Flask
 
 from {{cookiecutter.app_name}} import auth, api
-from {{cookiecutter.app_name}}.extensions import db, jwt
+from {{cookiecutter.app_name}}.extensions import db, jwt, migrate
 
 
 def create_app(config=None, testing=False):
@@ -35,6 +35,7 @@ def configure_extensions(app):
     """
     db.init_app(app)
     jwt.init_app(app)
+    migrate.init_app(app)
 
 
 def register_blueprints(app):

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/extensions.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/extensions.py
@@ -3,13 +3,18 @@
 All extensions here are used as singletons and
 initialized in application factory
 """
+
+from {{cookiecutter.app_name}} import app
+
 from flask_sqlalchemy import SQLAlchemy
 from passlib.context import CryptContext
 from flask_jwt_extended import JWTManager
 from flask_marshmallow import Marshmallow
-
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
 jwt = JWTManager()
 ma = Marshmallow()
+migrate = Mirage(app, db)
+
 pwd_context = CryptContext(schemes=['pbkdf2_sha256'], deprecated='auto')

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/extensions.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/extensions.py
@@ -15,6 +15,6 @@ from flask_migrate import Migrate
 db = SQLAlchemy()
 jwt = JWTManager()
 ma = Marshmallow()
-migrate = Mirage(app, db)
+migrate = Migrate(app, db)
 
 pwd_context = CryptContext(schemes=['pbkdf2_sha256'], deprecated='auto')


### PR DESCRIPTION
Maybe it's me, but I can't make the flask-migrate work. When I try and use it, it comes up with a keyerror['migrate']. 

I think it's because the Migrate object isn't initiated and then isn't registered. This PR does those two things.

I don't love the solution, because I'm importing the app into extensions and it seems inelegant but everything seems to work OK now. 