### PR TITLE
Add default security to all endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 matrix:
   include:
-    - name: "python 3.5"
-      python: 3.5
-      env: TOXENV=py35
     - name: "python 3.6"
       python: 3.6
       env: TOXENV=py36
     - name: "python 3.7"
+      python: 3.7
+      env: TOXENV=py37
 
 before_install:
   - "pip3 install --upgrade pip cookiecutter"

--- a/{{cookiecutter.project_name}}/tox.ini
+++ b/{{cookiecutter.project_name}}/tox.ini
@@ -2,7 +2,7 @@
 max-line-length = 120
 
 [tox]
-envlis = py35,py36,py37
+envlist = py36,py37
 
 [testenv]
 deps=

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
@@ -34,7 +34,7 @@ def configure_extensions(app, cli):
 def configure_apispec(app):
     """Configure APISpec for swagger support
     """
-    apispec.init_app(app)
+    apispec.init_app(app, security=[{"jwt": []}])
     apispec.spec.components.security_scheme("jwt", {
         "type": "http",
         "scheme": "bearer",

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/commons/apispec.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/commons/apispec.py
@@ -32,13 +32,13 @@ class FlaskRestfulPlugin(FlaskPlugin):
 class APISpecExt:
     """Very simple and small extension to use apispec with this API as a flask extension
     """
-    def __init__(self, app=None):
+    def __init__(self, app=None, **kwargs):
         self.spec = None
 
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, **kwargs)
 
-    def init_app(self, app):
+    def init_app(self, app, **kwargs):
         app.config.setdefault("APISPEC_TITLE", "{{cookiecutter.project_name}}")
         app.config.setdefault("APISPEC_VERSION", "1.0.0")
         app.config.setdefault("OPENAPI_VERSION", "3.0.2")
@@ -51,6 +51,7 @@ class APISpecExt:
             version=app.config["APISPEC_VERSION"],
             openapi_version=app.config["OPENAPI_VERSION"],
             plugins=[MarshmallowPlugin(), FlaskRestfulPlugin()],
+            **kwargs
         )
 
         blueprint = Blueprint(


### PR DESCRIPTION
@karec I was able to find a solution to the issue with Swagger not sending the bearer token. As you suggested, I enabled jwt for all endpoints. `/auth/login` already had `security: []` added.