### PR TITLE
Fix celery's task import

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/celery_app.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/celery_app.py
@@ -1,4 +1,4 @@
 from {{cookiecutter.app_name}}.app import init_celery
 
 app = init_celery()
-app.conf.imports = app.conf.imports + ("{{cookiecutter.app_name}}.tasks",)
+app.conf.imports = app.conf.imports + ("{{cookiecutter.app_name}}.tasks.example",)


### PR DESCRIPTION
I tried using celery, but it was unable to find the task in example.py.
After reading the docs, turns out we have to provide module names, not packages to the import config.

Now it works fine:)

see: http://docs.celeryproject.org/en/latest/userguide/configuration.html#imports