### PR TITLE
.flaskenv should respect use_celery config

### DIFF
--- a/{{cookiecutter.project_name}}/.flaskenv
+++ b/{{cookiecutter.project_name}}/.flaskenv
@@ -2,5 +2,7 @@ FLASK_ENV=development
 FLASK_APP={{cookiecutter.app_name}}.app:create_app
 SECRET_KEY=changeme
 DATABASE_URI=sqlite:////tmp/{{cookiecutter.app_name}}.db
+{%- if cookiecutter.use_celery == "yes" %}
 CELERY_BROKER_URL=amqp://guest:guest@localhost/
 CELERY_RESULT_BACKEND_URL=amqp://guest:guest@localhost/
+{%- endif %}


### PR DESCRIPTION
The current .flaskenv file is generating celery-related config even when
the use_celery option is false.