### PR TITLE
Fixes to accommodate for before_app_first_request method deprecation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "project_name": "restful_api",
     "app_name": "myapi",
-    "python_version": ["3.8", "3.7", "3.6"],
+    "python_version": ["3.11", "3.10", "3.9", "3.8"],
     "tox_python_env": "py{{ cookiecutter.python_version|replace('.','') }}",
     "use_celery": ["no", "yes"],
     "admin_user_username": "admin",

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/api/views.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/api/views.py
@@ -14,7 +14,6 @@ api.add_resource(UserResource, "/users/<int:user_id>", endpoint="user_by_id")
 api.add_resource(UserList, "/users", endpoint="users")
 
 
-@blueprint.before_app_first_request
 def register_views():
     apispec.spec.components.schema("UserSchema", schema=UserSchema)
     apispec.spec.path(view=UserResource, app=current_app)

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/app.py
@@ -20,8 +20,8 @@ def create_app(testing=False):
 
     configure_extensions(app)
     configure_cli(app)
-    configure_apispec(app)
     register_blueprints(app)
+    configure_apispec(app)
 {%- if cookiecutter.use_celery == "yes" %}
     init_celery(app)
 {%- endif %}
@@ -58,6 +58,9 @@ def configure_apispec(app):
             }
         },
     )
+    with app.app_context():
+        api.views.register_views()
+        auth.views.register_views()
 
 
 def register_blueprints(app):

--- a/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/auth/views.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.app_name}}/auth/views.py
@@ -185,7 +185,6 @@ def check_if_token_revoked(jwt_headers, jwt_payload):
     return is_token_revoked(jwt_payload)
 
 
-@blueprint.before_app_first_request
 def register_views():
     apispec.spec.path(view=login, app=app)
     apispec.spec.path(view=refresh, app=app)


### PR DESCRIPTION
The method `Blueprint.before_app_first_request` has been removed (prior deprecation) as per flask 2.3.0 (see pallets/flask#4995 )

Also updates choices of Python versions since support for Python 3.7 and below has been dropped: pallets/flask#5072